### PR TITLE
Update minimum Atom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "engines": {
-    "atom": ">=1.4.0 <2.0.0"
+    "atom": ">=1.7.0 <2.0.0"
   },
   "configSchema": {
     "executable": {


### PR DESCRIPTION
Updates the mimimum Atom version to be v1.7.0 for `requestIdleCallback` support.

Fixes #16.